### PR TITLE
ENG-995: bond info

### DIFF
--- a/apps/contracts/src/Incentives.sol
+++ b/apps/contracts/src/Incentives.sol
@@ -178,7 +178,7 @@ contract Incentives is Ownable, ReentrancyGuard {
         Conditions _terms
     ) internal {
         require(registry.isAllowed(_token), "Token not registered for incentives");
-        require(_initiativeId < signalsContract.totalInitiatives(), "Invalid initiative");
+        require(_initiativeId <= signalsContract.initiativeCount(), "Invalid initiative");
 
         IERC20 token = IERC20(_token);
         require(token.balanceOf(msg.sender) >= _amount, "Insufficient balance");

--- a/apps/contracts/src/Signals.sol
+++ b/apps/contracts/src/Signals.sol
@@ -597,7 +597,7 @@ contract Signals is ERC721Enumerable, Ownable, ReentrancyGuard {
      * @notice Returns all token IDs owned by an address
      * @param owner The address to return the tokens for
      */
-    function openPositions(address owner) public view returns (uint256[] memory) {
+    function listPositions(address owner) public view returns (uint256[] memory) {
         uint256 tokenCount = balanceOf(owner);
         uint256[] memory tokens = new uint256[](tokenCount);
 

--- a/apps/contracts/src/Signals.sol
+++ b/apps/contracts/src/Signals.sol
@@ -47,6 +47,7 @@ contract Signals is ERC721, Ownable, ReentrancyGuard {
         address proposer;
         uint256 timestamp;
         uint256 lastActivity;
+        uint256 underlyingLocked;
     }
 
     /// @notice Possible initiative states
@@ -212,7 +213,8 @@ contract Signals is ERC721, Ownable, ReentrancyGuard {
             body: body,
             proposer: msg.sender,
             timestamp: block.timestamp,
-            lastActivity: block.timestamp
+            lastActivity: block.timestamp,
+            underlyingLocked: 0
         });
 
         uint256 initiativeId = initiativeCount;
@@ -257,8 +259,13 @@ contract Signals is ERC721, Ownable, ReentrancyGuard {
         initiativeLocks[initiativeId].push(tokenId);
         supporterLocks[supporter].push(tokenId);
 
+        // Update the initiative's underlying locked amount
+        initiative.underlyingLocked += amount;
+
+        // Update the initiative's last activity timestamp
         initiative.lastActivity = block.timestamp;
 
+        // Inscribe the users support
         if (!isSupporter[initiativeId][supporter]) {
             supporters[initiativeId].push(supporter);
             isSupporter[initiativeId][supporter] = true;

--- a/apps/contracts/src/interfaces/IBondIssuer.sol
+++ b/apps/contracts/src/interfaces/IBondIssuer.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+struct BondInfo {
+  uint256 referenceId;
+  uint256 nominalValue;
+  uint256 expires;
+  uint256 created;
+  bool claimed;
+}
+
+interface IBondIssuer {
+    function getBondInfo(uint256 tokenId) external view returns (BondInfo memory);
+}

--- a/apps/contracts/test/Incentives.t.sol
+++ b/apps/contracts/test/Incentives.t.sol
@@ -69,7 +69,7 @@ contract IncentivesTest is Test, SignalsHarness {
         signals.proposeInitiative("Initiative 1", "Test adding incentives");
 
         // Add a 500 USDC bounty (4 times)
-        uint256 initiativeId = 0;
+        uint256 initiativeId = 1;
         address rewardToken = address(_usdc);
         uint256 amount = 500 * 1e6;
         uint256 expiresAt = 0;
@@ -104,7 +104,7 @@ contract IncentivesTest is Test, SignalsHarness {
         signals.proposeInitiativeWithLock("Initiative 1", "Test adding incentives", lockedAmount, 6);
 
         // Add a 500 USDC bounty (4 times)
-        uint256 initiativeId = 0;
+        uint256 initiativeId = 1;
         address rewardToken = address(_usdc);
         uint256 amount = 500 * 1e6;
         uint256 expiresAt = 0;

--- a/apps/contracts/test/Initiatives.t.sol
+++ b/apps/contracts/test/Initiatives.t.sol
@@ -104,14 +104,14 @@ contract InitiativesTest is Test, SignalsHarness {
         vm.stopPrank();
 
         // Retrieve the initiative and check the details
-        Signals.Initiative memory initiative = signals.getInitiative(0);
+        Signals.Initiative memory initiative = signals.getInitiative(1);
         assertEq(uint256(initiative.state), uint256(Signals.InitiativeState.Proposed));
         assertEq(initiative.title, title);
         assertEq(initiative.body, body);
         assertEq(address(initiative.proposer), _bob);
 
         // The weight should be equal to the amount of tokens locked
-        uint256 weight = signals.getWeightAt(0, block.timestamp);
+        uint256 weight = signals.getWeightAt(1, block.timestamp);
         assertEq(weight, amountToLock);
     }
 }

--- a/apps/contracts/test/Signals.sol
+++ b/apps/contracts/test/Signals.sol
@@ -1,3 +1,0 @@
-    // SPDX-License-Identifier: GPL-3.0-or-later
-
-pragma solidity ^0.8.24;

--- a/apps/contracts/test/SignalsTest.t.sol
+++ b/apps/contracts/test/SignalsTest.t.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
+import {SignalsHarness} from "./utils/SignalsHarness.sol";
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import "solmate/src/test/utils/mocks/MockERC20.sol";
 
+import {ISignals} from "../src/interfaces/ISignals.sol";
 import {Signals} from "../src/Signals.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-
-import {SignalsHarness} from "./utils/SignalsHarness.sol";
 
 contract SignalsTest is Test, SignalsHarness {
     Signals signals;
@@ -140,6 +140,23 @@ contract SignalsTest is Test, SignalsHarness {
         // Check that the initiative state is updated
         Signals.Initiative memory initiative = signals.getInitiative(0);
         assertEq(uint256(initiative.state), uint256(Signals.InitiativeState.Accepted));
+    }
+
+    /**
+     * TODO: Update this test to use the new bond details struct
+     * TODO: Update this test to use the new bond details struct
+     */
+    function test_reteriveBondDetails() public {
+        vm.startPrank(_alice);
+        _token.approve(address(signals), 100 * 1e18);
+        signals.proposeInitiativeWithLock("Initiative 1", "Description 1", 100 * 1e18, 6);
+
+        // Check that the bond details are correct
+        ISignals.LockInfo memory lockInfo = signals.getTokenMetadata(1);
+        assertEq(lockInfo.initiativeId, 0);
+        assertEq(lockInfo.tokenAmount, 100 * 1e18);
+        assertEq(lockInfo.lockDuration, 6);
+        assertEq(lockInfo.withdrawn, false);
     }
 
     /// Test that only the owner can accept an initiative

--- a/apps/contracts/test/SignalsTest.t.sol
+++ b/apps/contracts/test/SignalsTest.t.sol
@@ -19,7 +19,7 @@ contract SignalsTest is Test, SignalsHarness {
         (, signals) = deploySignalsWithFactory(dealTokens);
     }
 
-    function testDefaultConfig() public view {
+    function test_defaultConfig() public view {
         assertEq(signals.owner(), address(_deployer));
         assertEq(signals.underlyingToken(), address(_token));
         assertEq(signals.proposalThreshold(), defaultConfig.proposalThreshold);
@@ -34,7 +34,7 @@ contract SignalsTest is Test, SignalsHarness {
     /**
      * @notice Test revert when proposing an initiative with insufficient tokens
      */
-    function testProposeInitiativeRevertsWithInsufficientTokens() public {
+    function test_proposeInitiativeRevertsWithInsufficientTokens() public {
         vm.startPrank(_charlie);
         vm.expectRevert(Signals.InsufficientTokens.selector);
         signals.proposeInitiative("Should revert", "Description 1");
@@ -44,7 +44,7 @@ contract SignalsTest is Test, SignalsHarness {
     /**
      * @notice Test proposing an initiative without locking tokens
      */
-    function testProposeInitiative() public {
+    function test_proposeInitiative() public {
         vm.startPrank(_alice);
         _token.approve(address(signals), defaultConfig.proposalThreshold);
 
@@ -66,7 +66,7 @@ contract SignalsTest is Test, SignalsHarness {
     /**
      * @notice Test proposing an initiative with locked tokens
      */
-    function testProposeInitiativeWithLock() public {
+    function test_proposeInitiativeWithLock() public {
         vm.startPrank(_bob);
         // Approve the total amount needed (proposal threshold + locked amount)
         _token.approve(address(signals), defaultConfig.proposalThreshold * 2);
@@ -102,7 +102,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     /// Test supporting an initiative with locked tokens
-    function testSupportInitiative() public {
+    function test_supportInitiative() public {
         vm.startPrank(_alice);
 
         // Propose an initiative
@@ -127,7 +127,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     /// Test accepting an initiative
-    function testAcceptInitiative() public {
+    function test_acceptInitiative() public {
         // Propose an initiative
         vm.startPrank(_alice);
         _token.approve(address(signals), 100 * 1e18);
@@ -143,7 +143,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     /// Test that only the owner can accept an initiative
-    function test_OnlyOwnerCanAccept() public {
+    function test_onlyOwnerCanAccept() public {
         // Propose an initiative
         vm.startPrank(_alice);
         _token.approve(address(signals), 100 * 1e18);
@@ -155,7 +155,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     /// Test redeeming tokens after initiative is accepted
-    function testRedemptions() public {
+    function test_redemptions() public {
         // Propose an initiative with lock
         vm.startPrank(_bob);
         _token.approve(address(signals), 200 * 1e18);
@@ -182,7 +182,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     /// Test redeeming tokens before initiative is accepted (should fail)
-    function testCannotRedeemBeforeAcceptance() public {
+    function test_cannotRedeemBeforeAcceptance() public {
         // Propose an initiative with lock
         vm.startPrank(_bob);
         _token.approve(address(signals), 200 * 1e18);
@@ -196,7 +196,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     /// Test redeeming multiple escrow locks
-    function testRedeemMany() public {
+    function test_redeemMany() public {
         // Propose an initiative with lock
         vm.startPrank(_alice);
         _token.approve(address(signals), 100 * 1e18);
@@ -219,7 +219,7 @@ contract SignalsTest is Test, SignalsHarness {
         uint256 balanceBefore = _token.balanceOf(_alice);
 
         // List all NFTs owned by the alice
-        uint256[] memory nfts = signals.openPositions(_alice);
+        uint256[] memory nfts = signals.listPositions(_alice);
         assertEq(nfts.length, 3);
 
         // Iterate over the NFTs and redeem them
@@ -234,8 +234,20 @@ contract SignalsTest is Test, SignalsHarness {
         assertEq(balanceDifference, 325 * 1e18);
     }
 
+    function test_listBondsByOwner() public {
+        vm.startPrank(_alice);
+        _token.approve(address(signals), 100 * 1e18);
+        signals.proposeInitiativeWithLock("Initiative 1", "Description 1", 100 * 1e18, 6);
+        vm.stopPrank();
+
+        vm.startPrank(_alice);
+        uint256[] memory nfts = signals.listPositions(_alice);
+        assertEq(nfts.length, 1);
+        assertEq(nfts[0], 1);
+    }
+
     /// Test expiring an initiative after inactivity
-    function testExpireInitiative() public {
+    function test_expireInitiative() public {
         // Propose an initiative
         vm.startPrank(_alice);
         _token.approve(address(signals), 100 * 1e18);
@@ -252,7 +264,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     // Test attempting to expire an initiative before inactivity threshold (should fail)
-    function testExpireInitiativeBeforeThreshold() public {
+    function test_expireInitiativeBeforeThreshold() public {
         // Propose an initiative
         vm.startPrank(_alice);
         _token.approve(address(signals), 100 * 1e18);
@@ -267,7 +279,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     /// Test withdrawing tokens after initiative is expired
-    function testredeemAfterExpiration() public {
+    function test_redeemAfterExpiration() public {
         // Propose an initiative with lock
         vm.startPrank(_bob);
         _token.approve(address(signals), 200 * 1e18);
@@ -292,7 +304,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     // Test updating inactivity threshold as owner
-    function testSetInactivityThreshold() public {
+    function test_setInactivityThreshold() public {
         // Update the inactivity threshold
         vm.startPrank(_deployer);
         signals.setInactivityThreshold(30 days);
@@ -301,14 +313,14 @@ contract SignalsTest is Test, SignalsHarness {
         assertEq(signals.activityTimeout(), 30 days);
     }
 
-    function test_SetInactivityThresholdOnlyOwner() public {
+    function test_setInactivityThresholdOnlyOwner() public {
         vm.startPrank(_alice);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _alice));
         signals.setInactivityThreshold(30 days);
     }
 
     // Test that users cannot redeem tokens twice
-    function testCannotRedeemTwice() public {
+    function test_cannotRedeemTwice() public {
         // Propose an initiative with lock
         vm.startPrank(_bob);
         _token.approve(address(signals), 200 * 1e18);
@@ -328,7 +340,7 @@ contract SignalsTest is Test, SignalsHarness {
     }
 
     /// Test that redeeming multiple escrow locks only withdraws from initiatives in withdrawable state
-    function testRedeemManyPartialWithdrawal() public {
+    function test_redeemManyPartialWithdrawal() public {
         // Propose initiative with lock
         vm.startPrank(_bob);
         _token.approve(address(signals), defaultConfig.proposalThreshold);


### PR DESCRIPTION
Feature: 

- Added IBondIssuer interface, with BondInfo struct
- Added getBondInfo() function to Signals.sol

** Major change **
I updated `initiativeId` to start from 1 (not 0). This is a very common style choice across ERC20, ERC721, Nouns, etc. where ID numbers start from 1, and an ID of 0 means the value is not initialized/does not exist/something went wrong.
