### PR TITLE
feat(interface): Add network switcher combobox to top nav (ENG-953)

### DIFF
--- a/apps/interface/package.json
+++ b/apps/interface/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ponder/client": "^0.10.4",
     "@privy-io/react-auth": "^3.8.1",
+    "@web3icons/react": "^4.0.26",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "1.1.1",

--- a/apps/interface/src/components/containers/network-switcher.tsx
+++ b/apps/interface/src/components/containers/network-switcher.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import * as React from 'react'
+import { Check, ChevronsUpDown } from 'lucide-react'
+import { NetworkIcon } from '@web3icons/react'
+import { useRouter } from 'next/navigation'
+
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+
+import { SUPPORTED_NETWORKS } from '@/config/supported-networks'
+import type { SupportedNetworks } from '@/config/network-types'
+import { useNetworkStore } from '@/stores/useNetworkStore'
+import { getNetworkUrl } from '@/lib/routing'
+
+export function NetworkSwitcher() {
+  const [open, setOpen] = React.useState(false)
+  const selected = useNetworkStore((s) => s.selected)
+  const setNetwork = useNetworkStore((s) => s.setNetwork)
+  const router = useRouter()
+
+  const current = SUPPORTED_NETWORKS.find((n) => n.key === selected)
+
+  const handleSelect = (key: SupportedNetworks) => {
+    if (key === selected) {
+      setOpen(false)
+      return
+    }
+    setNetwork(key)
+    router.push(getNetworkUrl(key))
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label="Switch network"
+          className="gap-2 px-3"
+        >
+          {current && (
+            <NetworkIcon
+              network={current.iconVariant}
+              variant="branded"
+              className="h-4 w-4 shrink-0"
+            />
+          )}
+          <span className="hidden sm:inline text-sm">{current?.label ?? 'Select network'}</span>
+          <ChevronsUpDown className="h-3 w-3 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-52 p-0" align="end">
+        <Command>
+          <CommandEmpty>No networks found.</CommandEmpty>
+          <CommandGroup>
+            {SUPPORTED_NETWORKS.map((network) => (
+              <CommandItem
+                key={network.key}
+                value={network.key}
+                onSelect={() => handleSelect(network.key as SupportedNetworks)}
+                className="gap-2"
+              >
+                <NetworkIcon
+                  network={network.iconVariant}
+                  variant="branded"
+                  className="h-4 w-4 shrink-0"
+                />
+                <span>{network.label}</span>
+                <Check
+                  className={cn(
+                    'ml-auto h-4 w-4',
+                    selected === network.key ? 'opacity-100' : 'opacity-0',
+                  )}
+                />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/interface/src/components/containers/network-switcher.tsx
+++ b/apps/interface/src/components/containers/network-switcher.tsx
@@ -54,7 +54,7 @@ export function NetworkSwitcher() {
         >
           {current && (
             <NetworkIcon
-              network={current.iconVariant}
+              name={current.iconVariant}
               variant="branded"
               className="h-4 w-4 shrink-0"
             />
@@ -75,7 +75,7 @@ export function NetworkSwitcher() {
                 className="gap-2"
               >
                 <NetworkIcon
-                  network={network.iconVariant}
+                  name={network.iconVariant}
                   variant="branded"
                   className="h-4 w-4 shrink-0"
                 />

--- a/apps/interface/src/components/containers/topnav.tsx
+++ b/apps/interface/src/components/containers/topnav.tsx
@@ -3,6 +3,7 @@ import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { ConnectButton } from '@/components/web3/connect-button'
 import { Breadcrumbs } from './breadcrumbs'
 import { SidebarTrigger } from '../ui/sidebar'
+import { NetworkSwitcher } from './network-switcher'
 
 export const TopNav = () => {
   return (
@@ -16,6 +17,7 @@ export const TopNav = () => {
             <SidebarTrigger />
           </div>
           <div className="hidden lg:flex items-center gap-4">
+            <NetworkSwitcher />
             <ConnectButton />
             <ThemeToggle className="" />
           </div>

--- a/apps/interface/src/config/supported-networks.ts
+++ b/apps/interface/src/config/supported-networks.ts
@@ -1,0 +1,21 @@
+import type { SupportedNetworks } from './network-types'
+
+export interface SupportedNetworkEntry {
+  key: SupportedNetworks
+  label: string
+  /** Icon variant key for @web3icons/react NetworkIcon */
+  iconVariant: string
+}
+
+export const SUPPORTED_NETWORKS: SupportedNetworkEntry[] = [
+  {
+    key: 'baseSepolia',
+    label: 'Base Sepolia',
+    iconVariant: 'base',
+  },
+  {
+    key: 'arbitrumSepolia',
+    label: 'Arbitrum Sepolia',
+    iconVariant: 'arbitrum',
+  },
+]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@privy-io/react-auth':
         specifier: ^3.8.1
         version: 3.8.1(@solana-program/system@0.8.1(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(@solana-program/token@0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@18.3.1))(@types/react@18.3.26)(@upstash/redis@1.35.5)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@web3icons/react':
+        specifier: ^4.0.26
+        version: 4.0.26(react@18.3.1)(typescript@5.9.3)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -13900,7 +13903,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.7.4
       uuid: 9.0.1
@@ -19170,6 +19173,13 @@ snapshots:
   '@web3icons/common@0.11.20(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
+
+  '@web3icons/react@4.0.26(react@18.3.1)(typescript@5.9.3)':
+    dependencies:
+      '@web3icons/common': 0.11.20(typescript@5.9.3)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - typescript
 
   '@web3icons/react@4.0.26(react@19.2.0)(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
## Summary

Implements ENG-953 — adds a network switcher to the top nav using a shadcn combobox.

## Changes

- **`src/config/supported-networks.ts`** — static config file listing supported networks (Base Sepolia, Arbitrum Sepolia) with their `@web3icons/react` icon variant keys
- **`src/components/containers/network-switcher.tsx`** — `NetworkSwitcher` component; shadcn `Popover` + `Command` combobox, each item renders `<NetworkIcon>` + network name; on select wires to `useNetworkStore` and `router.push(getNetworkUrl(key))`
- **`src/components/containers/topnav.tsx`** — mounts `<NetworkSwitcher />` in the right-side desktop nav, between breadcrumbs and `<ConnectButton />`
- Installs `@web3icons/react`

## Notes

- Unichain Sepolia is not yet in `SupportedNetworks` / `NETWORK_CONFIG` — can be added once chain config is wired; static file is the only place that needs updating
- Existing `NetworkSwitcherDialog` is untouched
- Build confirmed clean (`pnpm --filter interface build` ✓)
- Branch based off `develop`