### PR TITLE
feat(interface): Surface Accept action for initiatives that meet threshold (ENG-1081)

### DIFF
--- a/apps/interface/src/components/containers/initiatives/initiative-card.tsx
+++ b/apps/interface/src/components/containers/initiatives/initiative-card.tsx
@@ -42,7 +42,7 @@ export const InitiativeCard: React.FC<Props> = ({ initiative }) => {
   const openDrawer = useSupportDrawerStore((state) => state.openDrawer)
   const { address } = useAccount()
   const { authenticated, login } = usePrivy()
-  const { boardAddress } = useSignals()
+  const { boardAddress, board } = useSignals()
   const publicClient = usePublicClient()
   const walletClient = useWalletClient()
   const fetchInitiatives = useInitiativesStore((state) => state.fetchInitiatives)
@@ -51,9 +51,39 @@ export const InitiativeCard: React.FC<Props> = ({ initiative }) => {
   const [isAcceptedDialogOpen, setIsAcceptedDialogOpen] = useState(false)
 
   const supportPercentage = Number.parseFloat(String(initiative.support * 100))
-  const canAccept = supportPercentage > 100 && initiative.status === 'active'
   const isAccepted = initiative.status === 'accepted'
   const isCancelled = initiative.status === 'archived'
+
+  // Board acceptance permissions
+  // AcceptancePermissions: 0 = Permissionless, 1 = OnlyOwner
+  // ThresholdOverride: 0 = None (must meet threshold), 1 = OnlyOwner (owner can bypass)
+  const permissions = board.acceptanceCriteria?.permissions ?? 0
+  const thresholdOverride = board.acceptanceCriteria?.thresholdOverride ?? 0
+  const thresholdMet = supportPercentage >= 100
+  const isOwner = !!(
+    address &&
+    board.owner &&
+    address.toLowerCase() === board.owner.toLowerCase()
+  )
+
+  let canAccept = false
+  if (initiative.status === 'active') {
+    if (permissions === 1) {
+      // OnlyOwner: only the board owner can accept
+      if (isOwner) {
+        // Owner can accept if threshold met, or if they can bypass (thresholdOverride = 1)
+        canAccept = thresholdMet || thresholdOverride === 1
+      }
+    } else {
+      // Permissionless: anyone can accept when threshold is met
+      if (thresholdMet) {
+        canAccept = true
+      } else if (isOwner && thresholdOverride === 1) {
+        // Owner can bypass threshold
+        canAccept = true
+      }
+    }
+  }
 
   // Determine if proposer is showing a hex address (no ENS)
   const isHexProposer = proposerName === shortAddress(initiative.proposer)

--- a/apps/interface/src/components/dialogs/accept-initiative-dialog.tsx
+++ b/apps/interface/src/components/dialogs/accept-initiative-dialog.tsx
@@ -56,6 +56,21 @@ export function AcceptInitiativeDialog({
       ? `${acceptanceThreshold} ${underlyingSymbol}`
       : acceptanceThreshold
 
+  // Determine token release behaviour from board config
+  const releaseLockSeconds = board.lockingConfig?.releaseLockDuration
+    ? Number(board.lockingConfig.releaseLockDuration)
+    : 0
+  const hasTimelock = releaseLockSeconds > 0
+  const releaseLockLabel = (() => {
+    if (!hasTimelock) return null
+    const days = Math.floor(releaseLockSeconds / 86400)
+    const hours = Math.floor((releaseLockSeconds % 86400) / 3600)
+    if (days > 0 && hours > 0) return `${days}d ${hours}h`
+    if (days > 0) return `${days} day${days !== 1 ? 's' : ''}`
+    if (hours > 0) return `${hours} hour${hours !== 1 ? 's' : ''}`
+    return `${releaseLockSeconds} seconds`
+  })()
+
   const handleAccept = async () => {
     await onAccept()
     onOpenChange(false)
@@ -120,8 +135,10 @@ export function AcceptInitiativeDialog({
 
           <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/20">
             <p className="text-sm text-amber-900 dark:text-amber-200">
-              <strong>Note:</strong> Accepting an initiative is permanent and cannot be undone. Once
-              accepted, supporters can redeem their locked tokens after any release timelock period.
+              <strong>Note:</strong> Accepting an initiative is permanent and cannot be undone.{' '}
+              {hasTimelock
+                ? `Once accepted, supporters can redeem their locked tokens after the ${releaseLockLabel} release timelock has elapsed.`
+                : 'Once accepted, supporters can redeem their locked tokens immediately.'}
             </p>
           </div>
         </div>

--- a/apps/interface/src/components/dialogs/accepted-initiative-dialog.tsx
+++ b/apps/interface/src/components/dialogs/accepted-initiative-dialog.tsx
@@ -36,6 +36,21 @@ export function AcceptedInitiativeDialog({
   const supportPercentage = Number.parseFloat(String(initiative.support * 100))
   const hasAttachments = initiative.attachments && initiative.attachments.length > 0
 
+  // Determine token release behaviour from board config
+  const releaseLockSeconds = board.lockingConfig?.releaseLockDuration
+    ? Number(board.lockingConfig.releaseLockDuration)
+    : 0
+  const hasTimelock = releaseLockSeconds > 0
+  const releaseLockLabel = (() => {
+    if (!hasTimelock) return null
+    const days = Math.floor(releaseLockSeconds / 86400)
+    const hours = Math.floor((releaseLockSeconds % 86400) / 3600)
+    if (days > 0 && hours > 0) return `${days}d ${hours}h`
+    if (days > 0) return `${days} day${days !== 1 ? 's' : ''}`
+    if (hours > 0) return `${hours} hour${hours !== 1 ? 's' : ''}`
+    return `${releaseLockSeconds} seconds`
+  })()
+
   const proposerName = useAsyncProp(
     resolveName(initiative.proposer),
     shortAddress(initiative.proposer),
@@ -70,7 +85,10 @@ export function AcceptedInitiativeDialog({
             <DialogTitle>Accepted Initiative</DialogTitle>
           </div>
           <DialogDescription>
-            This initiative has been accepted and can now be actioned by the community. Supporters can redeem their locked tokens after the refund delay.
+            This initiative has been accepted and can now be actioned by the community.{' '}
+            {hasTimelock
+              ? `Supporters can redeem their locked tokens after the ${releaseLockLabel} release timelock has elapsed.`
+              : 'Supporters can redeem their locked tokens immediately.'}
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-6">

--- a/apps/protocol/test/signals/Lifecycle.t.sol
+++ b/apps/protocol/test/signals/Lifecycle.t.sol
@@ -283,6 +283,92 @@ contract SignalsLifecycleTest is Test, SignalsHarness {
         assertEq(uint256(initiative.state), uint256(ISignals.InitiativeState.Accepted));
     }
 
+    /// Test that locked tokens can be redeemed immediately after acceptance when releaseLockDuration is 0
+    function test_Accept_Redeem_ImmediateRelease() public {
+        // Default config has releaseLockDuration = 0 (immediate release after acceptance)
+        uint256 lockAmount = defaultConfig.acceptanceCriteria.minThreshold;
+        uint256 beforeBalance = _tokenERC20.balanceOf(_alice);
+
+        // Propose and meet threshold
+        vm.startPrank(_alice);
+        _tokenERC20.approve(address(signals), lockAmount);
+        signals.proposeInitiativeWithLock(_metadata(1), lockAmount, 1);
+        vm.stopPrank();
+
+        // Owner accepts the initiative
+        vm.startPrank(_deployer);
+        signals.acceptInitiative(1);
+        vm.stopPrank();
+
+        // Verify initiative is accepted
+        ISignals.Initiative memory initiative = signals.getInitiative(1);
+        assertEq(uint256(initiative.state), uint256(ISignals.InitiativeState.Accepted));
+
+        // Alice can redeem immediately (releaseLockDuration = 0)
+        vm.startPrank(_alice);
+        uint256[] memory lockIds = new uint256[](1);
+        lockIds[0] = 1;
+        signals.redeemLocksForInitiative(1, lockIds);
+        vm.stopPrank();
+
+        // Verify tokens returned
+        ISignals.TokenLock memory lock = signals.getTokenLock(1);
+        assertEq(lock.withdrawn, true);
+        assertEq(_tokenERC20.balanceOf(_alice), beforeBalance);
+    }
+
+    /// Test that locked tokens cannot be redeemed before releaseLockDuration elapses after acceptance
+    function test_Accept_Redeem_AfterReleaseLockDuration() public {
+        uint256 releaseLock = 7 days;
+
+        // Configure board with a post-acceptance release timelock
+        ISignals.BoardConfig memory config = defaultConfig;
+        config.lockingConfig.releaseLockDuration = releaseLock;
+        config.acceptanceCriteria.permissions = ISignals.AcceptancePermissions.OnlyOwner;
+        config.acceptanceCriteria.thresholdOverride = ISignals.ThresholdOverride.OnlyOwner;
+
+        ISignals customSignals = deploySignals(config);
+
+        uint256 lockAmount = defaultConfig.proposerRequirements.minBalance;
+        uint256 beforeBalance = _tokenERC20.balanceOf(_alice);
+
+        // Propose with a lock
+        vm.startPrank(_alice);
+        _tokenERC20.approve(address(customSignals), lockAmount);
+        customSignals.proposeInitiativeWithLock(_metadata(1), lockAmount, 1);
+        vm.stopPrank();
+
+        // Owner accepts
+        vm.startPrank(_deployer);
+        customSignals.acceptInitiative(1);
+        vm.stopPrank();
+
+        // Verify accepted
+        ISignals.Initiative memory initiative = customSignals.getInitiative(1);
+        assertEq(uint256(initiative.state), uint256(ISignals.InitiativeState.Accepted));
+
+        // Immediate redemption should fail — release timelock not yet passed
+        vm.startPrank(_alice);
+        uint256[] memory lockIds = new uint256[](1);
+        lockIds[0] = 1;
+        vm.expectRevert(abi.encodeWithSelector(ISignals.Signals_StillTimelocked.selector, 1));
+        customSignals.redeemLocksForInitiative(1, lockIds);
+        vm.stopPrank();
+
+        // Warp past the release lock duration
+        vm.warp(block.timestamp + releaseLock + 1);
+
+        // Now redemption should succeed
+        vm.startPrank(_alice);
+        customSignals.redeemLocksForInitiative(1, lockIds);
+        vm.stopPrank();
+
+        // Verify tokens returned
+        ISignals.TokenLock memory lock = customSignals.getTokenLock(1);
+        assertEq(lock.withdrawn, true);
+        assertEq(_tokenERC20.balanceOf(_alice), beforeBalance);
+    }
+
     /*//////////////////////////////////////////////////////////////
                         LOCK DURATION TESTS
     //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
## Summary

The contract side for initiative acceptance was already complete (`Lifecycle.t.sol`). This PR wires up the interface to correctly surface the Accept action and handle both immediate and timelocked token release based on board config.

## Changes

- **`initiative-card.tsx`**: Replaced the naive `supportPercentage > 100` check with a full permissions-aware `canAccept` derivation:
  - `AcceptancePermissions.OnlyOwner` (1): Accept button only shows to the board owner
  - `ThresholdOverride.OnlyOwner` (1): Owner sees Accept even before threshold is met
  - `AcceptancePermissions.Permissionless` (0) + threshold met: Accept shows to anyone
  - `AcceptancePermissions.Permissionless` (0) + owner + ThresholdOverride.OnlyOwner: Accept shows to owner unconditionally

- **`accept-initiative-dialog.tsx`**: Added `releaseLockDuration` from `lockingConfig` to derive whether tokens are released immediately or after a timelock. The note in the dialog now reads accurately ("immediately" vs "after the Xd Yh release timelock").

- **`accepted-initiative-dialog.tsx`**: Same timelock derivation applied to the description shown for already-accepted initiatives, so supporters know exactly when they can redeem.

## Skipped / Deferred

- No changes to contract code (already done per James)
- No on-chain changes; purely UI gating and copy

## Linear

Closes ENG-1081
