### PR TITLE
docs(ENG-1083): document proposer eligibility requirements for board configuration

### DIFF
--- a/apps/docs/pages/reference/board-configuration/eligibility-parameters.mdx
+++ b/apps/docs/pages/reference/board-configuration/eligibility-parameters.mdx
@@ -1,30 +1,161 @@
 ---
 title: "Eligibility Parameters"
-weight: 1
+weight: 2
 ---
 
 # Eligibility Parameters
 
-Signals uses the same `ParticipantRequirements` structure for both `proposerRequirements` and `supporterRequirements` in `BoardConfig`.
+`BoardConfig` controls who is allowed to **propose** and **support** initiatives via two separate fields:
+
+- `proposerRequirements` — gates who can call `proposeInitiative` / `proposeInitiativeWithLock`
+- `supporterRequirements` — gates who can call `supportInitiative`
+
+Both use the same `ParticipantRequirements` struct, and both are **immutable after deployment**.
 
 ```solidity
 struct ParticipantRequirements {
-    address token;            // Token used for eligibility checks
-    uint256 minBalance;         // Minimum current balance required
+    address token;              // Token used for eligibility checks
+    uint256 minBalance;         // Minimum current balance required (in wei)
     uint256 minHoldingDuration; // Minimum blocks tokens must be held (requires IVotes)
-    uint256 minLockAmount;      // Minimum tokens that must be locked
+    uint256 minLockAmount;      // Minimum tokens that must be locked per proposal/support
 }
 ```
 
-## Rules Derived From Fields
+---
 
-- `minBalance == 0` and `minHoldingDuration == 0`: no balance requirement.
-- `minBalance > 0` and `minHoldingDuration == 0`: current balance check only.
-- `minBalance > 0` and `minHoldingDuration > 0`: historical balance check (requires `IVotes` on the configured token).
-- `minLockAmount` enforces a minimum lock amount when proposing with a lock or supporting.
+## Proposer Requirement Modes
 
-## Constraints
+Eligibility mode is **inferred from the field values** — there is no explicit enum. The three modes are:
 
-- `token` must be set (cannot be `address(0)`).
-- `minHoldingDuration > 0` requires `minBalance > 0` and an `IVotes`-compatible token.
-- `minLockAmount` must be ≤ `minBalance`.
+### Mode 1 — No Requirement (Open)
+
+Anyone can propose regardless of token balance.
+
+```solidity
+// Set minBalance and minHoldingDuration to 0
+proposerRequirements: IAuthorizer.ParticipantRequirements({
+    token: address(underlyingToken), // still required (cannot be address(0))
+    minBalance: 0,
+    minHoldingDuration: 0,
+    minLockAmount: 0
+})
+```
+
+**When to use:** Fully open boards where any address can submit initiatives. Permissionless
+governance experiments, public suggestion boards, etc.
+
+---
+
+### Mode 2 — Minimum Balance
+
+Proposer must hold at least `minBalance` tokens at proposal time.
+
+```solidity
+// Set minBalance > 0, leave minHoldingDuration as 0
+proposerRequirements: IAuthorizer.ParticipantRequirements({
+    token: address(governanceToken),
+    minBalance: 100_000e18,   // e.g. 100,000 tokens
+    minHoldingDuration: 0,
+    minLockAmount: 0
+})
+```
+
+The contract checks `IERC20(token).balanceOf(proposer) >= minBalance` at the time of the call.
+
+**When to use:** Boards where token-holding alignment is a lightweight signal, but historical
+snapshot proofs aren't required. Works with any ERC20 token.
+
+---
+
+### Mode 3 — Minimum Balance Held for Duration
+
+Proposer must have held at least `minBalance` tokens continuously for at least `minHoldingDuration`
+blocks before the proposal.
+
+```solidity
+// Set both minBalance > 0 and minHoldingDuration > 0
+proposerRequirements: IAuthorizer.ParticipantRequirements({
+    token: address(governanceToken),
+    minBalance: 50_000e18,      // must currently hold ≥ 50,000 tokens
+    minHoldingDuration: 7200,   // must have held them for ≥ 7,200 blocks (~24h on Ethereum mainnet)
+    minLockAmount: 0
+})
+```
+
+The contract calls `IVotes(token).getPastVotes(proposer, block.number - minHoldingDuration)` and
+checks that the historical balance is also ≥ `minBalance`.
+
+> **⚠️ Requires a Governor-style token (IVotes / ERC20Votes)**
+>
+> `minHoldingDuration` only works with tokens that implement
+> [OpenZeppelin's `IVotes`](https://docs.openzeppelin.com/contracts/4.x/api/governance#IVotes)
+> interface (e.g. `ERC20Votes`, `ERC721Votes`). These tokens record checkpoint snapshots on every
+> transfer/delegation, enabling historical balance queries.
+>
+> Plain ERC20 tokens do **not** support this — the contract will revert with
+> `Signals_TokenHasNoCheckpointSupport` if `getPastVotes` is called on a non-IVotes token.
+> If you configure `minHoldingDuration > 0`, your `token` address **must** be IVotes-compatible.
+
+**When to use:** Higher-stakes boards where you want to prevent last-minute token accumulation to
+game proposal rights. Common in DAO governance to require "skin in the game" for a minimum period.
+
+---
+
+## `minLockAmount` — Minimum Lock Per Proposal
+
+`minLockAmount` can be combined with any of the above modes. When set, `proposeInitiativeWithLock`
+requires the caller to lock at least `minLockAmount` tokens alongside their proposal. Calling
+`proposeInitiative` (without a lock) when `minLockAmount > 0` will still revert.
+
+```solidity
+proposerRequirements: IAuthorizer.ParticipantRequirements({
+    token: address(underlyingToken),
+    minBalance: 50_000e18,
+    minHoldingDuration: 0,
+    minLockAmount: 10_000e18  // proposer must lock at least 10,000 tokens
+})
+```
+
+**Constraint:** `minLockAmount` must be ≤ `minBalance`.
+
+---
+
+## Constraints Summary
+
+| Field | Constraint |
+|---|---|
+| `token` | Cannot be `address(0)` |
+| `minHoldingDuration > 0` | Requires `minBalance > 0` **and** an `IVotes`-compatible token |
+| `minLockAmount` | Must be ≤ `minBalance` |
+
+Violating these at initialization will revert with `Signals_InvalidArguments`.
+
+---
+
+## Error Reference
+
+| Error | Cause |
+|---|---|
+| `Signals_InsufficientTokens` | Current balance < `minBalance` |
+| `Signals_InsufficientTokenDuration` | Historical balance < `minBalance` at `block.number - minHoldingDuration` |
+| `Signals_TokenHasNoCheckpointSupport` | Token doesn't implement `IVotes`; `getPastVotes` reverted |
+| `Signals_InsufficientLockAmount` | Lock amount < `minLockAmount` |
+| `Signals_InvalidArguments` | Invalid configuration at initialization (e.g. `minHoldingDuration > 0` with `minBalance == 0`) |
+
+---
+
+## Reading Requirements On-Chain
+
+```solidity
+// Check proposer requirements
+IAuthorizer.ParticipantRequirements memory reqs = signals.getProposerRequirements();
+
+// Check supporter requirements
+IAuthorizer.ParticipantRequirements memory reqs = signals.getParticipantRequirements();
+
+// Check whether a specific account can propose with a given lock amount
+bool canPropose = signals.accountCanPropose(account, lockAmount);
+
+// Check whether a specific account can support with a given lock amount
+bool canSupport = signals.accountCanSupport(account, lockAmount);
+```

--- a/apps/docs/pages/reference/eligibility.mdx
+++ b/apps/docs/pages/reference/eligibility.mdx
@@ -3,26 +3,38 @@ title: "Eligibility Requirements"
 weight: 3
 ---
 
-### Eligibility Requirements
+# Eligibility Requirements
 
 Signals uses the same `ParticipantRequirements` structure for both proposers and supporters:
 
 ```solidity
 struct ParticipantRequirements {
-    address token;            // Token used for eligibility checks
-    uint256 minBalance;       // Current balance requirement
-    uint256 minHoldingDuration; // Historical balance requirement (blocks)
-    uint256 minLockAmount;    // Minimum lock amount
+    address token;              // Token used for eligibility checks
+    uint256 minBalance;         // Minimum current balance required (in wei)
+    uint256 minHoldingDuration; // Minimum blocks tokens must be held (requires IVotes)
+    uint256 minLockAmount;      // Minimum tokens that must be locked
 }
 ```
 
-**Rules derived from fields:**
-- `minBalance == 0` and `minHoldingDuration == 0`: no balance requirement.
-- `minBalance > 0` and `minHoldingDuration == 0`: current balance check only.
-- `minBalance > 0` and `minHoldingDuration > 0`: historical balance check (requires `IVotes` on the configured `token`).
-- `minLockAmount` enforces a minimum lock amount for support or `proposeInitiativeWithLock`.
+Eligibility mode is inferred from field values — there is no explicit enum:
 
-**Constraints:**
-- `token` must be set (cannot be `address(0)`).
-- `minHoldingDuration > 0` requires `minBalance > 0` and an `IVotes`-compatible token.
+| Mode | `minBalance` | `minHoldingDuration` | Notes |
+|---|---|---|---|
+| **Open** — no requirement | `0` | `0` | Anyone can participate |
+| **Min Balance** | `> 0` | `0` | Current ERC20 balance check |
+| **Has Held Tokens** | `> 0` | `> 0` | Historical snapshot check; requires `IVotes` on `token` |
+
+**`minLockAmount`** can be combined with any mode to require a minimum lock per action.
+
+For a full explanation of each mode, constraints, and worked examples, see
+[Eligibility Parameters](/reference/board-configuration/eligibility-parameters).
+
+---
+
+## Key Constraints
+
+- `token` cannot be `address(0)`.
+- `minHoldingDuration > 0` requires `minBalance > 0` **and** an `IVotes`-compatible token (e.g. `ERC20Votes`). Plain ERC20s are not supported for duration checks.
 - `minLockAmount` must be ≤ `minBalance`.
+
+Both `proposerRequirements` and `supporterRequirements` are **immutable after deployment**.


### PR DESCRIPTION
## Summary

Documents the proposer eligibility/requirements configuration for Signals boards, addressing ENG-1083.

## Changes

- `apps/docs/pages/reference/board-configuration/eligibility-parameters.mdx` — eligibility parameter reference for board config
- `apps/docs/pages/reference/eligibility.mdx` — top-level eligibility reference page covering who is allowed to propose

## Linear

Closes ENG-1083